### PR TITLE
Chore/vagrant script

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -64,10 +64,13 @@ jobs:
               env:
                 SSH_KEY: ${{ secrets.SSH_KEY }}
         
-            - name: Deploy to server
+            - name: Deploy to servers
                 # Configure the ~./bash_profile and deploy.sh file on the Vagrantfile
-              run: >
+              run: |
                 ssh $SSH_USER@$SSH_HOST
+                -i ~/.ssh/minitwit.key -o StrictHostKeyChecking=no
+                './deploy.sh'
+                ssh $SSH_USER@167.71.40.81
                 -i ~/.ssh/minitwit.key -o StrictHostKeyChecking=no
                 './deploy.sh'
               env:

--- a/.gitignore
+++ b/.gitignore
@@ -236,4 +236,7 @@ appsettings.json
 # Optionally, uncomment the following line if you want to ignore the default appsettings.json as well
 # appsettings.json
 
+.vagrant/
+
 .secrets
+.secrets-*

--- a/.vagrant/bundler/global.sol
+++ b/.vagrant/bundler/global.sol
@@ -1,0 +1,1 @@
+{"dependencies":[["log4r",[">= 0"]],["json",[">= 0"]],["logger",[">= 0"]],["uri",[">= 0"]],["net-http",[">= 0"]],["faraday-net_http",[">= 2.0","< 3.4"]],["faraday",[">= 0.8.6"]],["vagrant-digitalocean",["= 0.9.6"]]],"checksum":"ddf8c9690978c23c2c275ff0154d161ca57f6c591cd4bc23e56357324c92589a","vagrant_version":"2.4.3"}

--- a/.vagrant/bundler/global.sol
+++ b/.vagrant/bundler/global.sol
@@ -1,1 +1,0 @@
-{"dependencies":[["log4r",[">= 0"]],["json",[">= 0"]],["logger",[">= 0"]],["uri",[">= 0"]],["net-http",[">= 0"]],["faraday-net_http",[">= 2.0","< 3.4"]],["faraday",[">= 0.8.6"]],["vagrant-digitalocean",["= 0.9.6"]]],"checksum":"ddf8c9690978c23c2c275ff0154d161ca57f6c591cd4bc23e56357324c92589a","vagrant_version":"2.4.3"}

--- a/.vagrant/rgloader/loader.rb
+++ b/.vagrant/rgloader/loader.rb
@@ -1,0 +1,12 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+# This file loads the proper rgloader/loader.rb file that comes packaged
+# with Vagrant so that encoded files can properly run with Vagrant.
+
+if ENV["VAGRANT_INSTALLER_EMBEDDED_DIR"]
+  require File.expand_path(
+    "rgloader/loader", ENV["VAGRANT_INSTALLER_EMBEDDED_DIR"])
+else
+  raise "Encoded files can't be read outside of the Vagrant installer."
+end

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Either way, the application is dependent on certain enviroment variables, which 
 
 # Dependencies
 
-Both docker compose and deploy.sh are dependen on a file called either .secrets-local for local developing,
+Both docker compose and deploy.sh are dependen on a file called either.secrets-local for local developing,
 or .secrets-production for the production enviroment.
 
 Both are located in the root directory:
@@ -14,7 +14,7 @@ Both are located in the root directory:
 ```/.secrets-production```
 
 A file called appsettings.json can also be sat, if one wants to run the dotnet application without continarization.
-It should have the following structure, and reside in the parth src/minitwit.Api/apisettings.json:
+It should have the following structure, and reside on the path ```src/minitwit.Api/apisettings.json```:
 
 ```sh
 "ConnectionStrings": {
@@ -30,7 +30,7 @@ It should have the following structure, and reside in the parth src/minitwit.Api
   }
 ```
 A file called .env can also be sat, if one wants to run the node.js application without continarization.
-It should have the following content, and reside in the parth src/minitwit.Web/.env:
+It should have the following content, and reside in the parth ```src/minitwit.Web/.env```:
 
 ```sh
 NODE_TLS_REJECT_UNAUTHORIZED=0
@@ -68,13 +68,13 @@ The containers can be brought down again by the command:
 docker compose down
 ```
 
-# Deploy.sh script
+# Using deploy.sh in local enviroment
 
 When it is ensured that the secrets file is in place, 
 the containers can be brought up by running the following command in the root directory of the project:
 
 ```sh
-/.deploy.sh
+/.deploy.sh --local
 ```
 
 Please note, that this action does not rebuild the containers from the local enviroment, but pulls the latest containers from the Docker Hub repository.
@@ -92,15 +92,22 @@ This is in order to ensure data consistency and the data of the database not bei
 To be able to provision the VM('s) with Vagrant the following dependencies must be in place:
 
 - Vagrant must be installed
-- .secrets-production file at the location /.secrets-production
+- .secrets-production file at the location ```/.secrets-production```
 - The <a href="https://github.com/devopsgroup-io/vagrant-digitalocean"><span>'vagrant-digitalocean'</span></a> plugin must be installed
 - A digital-ocean token must be set as an enviroment variable with following name:
+  
   ```sh
   DIGITAL_OCEAN_TOKEN
   ```
 - If running on WSL the following enviroment variable must be set:
+  
   ```sh
   export VAGRANT_WSL_ENABLE_WINDOWS_ACCESS="1"  
+  ```
+- In deploy.sh script, the enviroment file specified for the minitwit-api container must be changed from the ".secrets-local" to ".secrets-production":
+  
+  ```sh
+  docker run -d --network=minitwit-network -p 8080:8080 -p 8081:8081 --name=minitwit-api --env-file .secrets-production lukan707/minitwit-joel-api:latest
   ```
 
 ## Provision
@@ -149,7 +156,7 @@ The monitoring dashboard can be found at <http://localhost:9090>
 
 The monitoring dashboard can be found at <http://67.207.72.167:3001>
 
-# Manually triggering the deploy.sh script
+# Manually triggering the deploy.sh script on production
 
 Fist ssh into the VM on which you wish to manually trigger the deploy.sh script.
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ the containers can be brought up by running the following command in the root di
 /.deploy.sh
 ```
 
+Please note, that this action does not rebuild the containers from the local enviroment, but pulls the latest containers from the Docker Hub repository.
+
 # Provisioning the web droplet (VM) with Vagrant
 
 Please note that the following action, re-provision the VM('s) on digitalocean containing the API- and webserver.

--- a/README.md
+++ b/README.md
@@ -5,9 +5,13 @@ Either way, the application is dependent on certain enviroment variables, which 
 
 # Dependencies
 
-Both docker compose and deploy.sh are dependen on a file called .secrets located in the root directory:
+Both docker compose and deploy.sh are dependen on a file called either .secrets-local for local developing,
+or .secrets-production for the production enviroment.
 
-```/.secrets```
+Both are located in the root directory:
+
+```/.secrets-local```
+```/.secrets-production```
 
 A file called appsettings.json can also be sat, if one wants to run the dotnet application without continarization.
 It should have the following structure, and reside in the parth src/minitwit.Api/apisettings.json:
@@ -73,6 +77,38 @@ the containers can be brought up by running the following command in the root di
 /.deploy.sh
 ```
 
+# Provisioning the web droplet (VM) with Vagrant
+
+Please note that the following action, re-provision the VM('s) on digitalocean containing the API- and webserver.
+
+On purpose, the VM with the database is not defined within the Vagrantfile, and thus can not be provisioned
+with the following steps.
+This is in order to ensure data consistency and the data of the database not being deleted on accident.
+
+## Dependencies
+
+To be able to provision the VM('s) with Vagrant the following dependencies must be in place:
+
+- Vagrant must be installed
+- .secrets-production file at the location /.secrets-production
+- The <a href="https://github.com/devopsgroup-io/vagrant-digitalocean"><span>'vagrant-digitalocean'</span></a> plugin must be installed
+- A digital-ocean token must be set as an enviroment variable with following name:
+  ```sh
+  DIGITAL_OCEAN_TOKEN
+  ```
+- If running on WSL the following enviroment variable must be set:
+  ```sh
+  export VAGRANT_WSL_ENABLE_WINDOWS_ACCESS="1"  
+  ```
+
+## Provision
+
+To provision the VM('s) on digitalocean one must stand in the root directory of the project, and run the following command:
+
+```sh
+vagrant provision
+```
+
 # Viewing the web application
 
 ## Localhost
@@ -109,7 +145,7 @@ The monitoring dashboard can be found at <http://localhost:9090>
 
 ## Viewing metrics on production
 
-The monitoring dashboard can be found at
+The monitoring dashboard can be found at <http://67.207.72.167:3001>
 
 # Manually triggering the deploy.sh script
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,62 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+    ## Syncs files form the host to the guest vm mounting point (but not the other way)
+    config.vm.synced_folder ".", "/vagrant", type: "rsync"
+    config.vm.box = "generic/ubuntu2204"
+  
+    ## Database server
+    config.vm.define "db", primary:true do |server|
+      ## Defining db server on the private network, disallows access from the outside.
+      server.vm.network "private_network", ip: "192.168.20.2"
+  
+      server.vm.provider "minitwit-db" do |vb|
+        ## Is only on a gut feeling, we should check with the limitations of digigtalocean
+        vb.memory = "1024"
+      end
+      server.vm.hostname = "minitwit-db"
+      ## TODO: Setup of database:
+      server.vm.provision "shell", privileged: false, inline: <<-SHELL
+        echo "test"
+        SHELL
+    end
+  
+    ## Api server
+    config.vm.define "minitwit-api", pirmary: true do |server|
+      ## TODO: Change to public network, and integrate to work with digitalocean in order to expose to public
+      server.vm.network "private_network", ip: "192.168.20.3"
+      server.vm.provider "virtualbox" do |vb|
+        ## Is only on a gut feeling, we should check with the limitations of digigtalocean
+        vb.memory = "1024"
+      end
+      server.vm.hostname = "minitwit-api"
+      ## TODO: Setup of api, have not been tested
+      server.vm.provision "shell", privileged: false, inline: <<-SHELL
+        sudo apt-get update && \
+          sudo apt-get install -y dotnet-sdk-9.0
+  
+        dotnet publish "minitwit.Api/minitwit.Api.csproj" -c Release -o /app/publish /p:UseAppHost=false
+        dotnet /app/publish/minitwit.Api.dll
+      SHELL
+    end
+  
+    ## Web server
+    config.vm.define "minitwit-server", primary: true do |server|
+      ## TODO: Change to public network, and integrate to work with digitalocean in order to expose to public
+      server.vm.network "private_network", ip: "192.168.20.4"
+      server.vm.provider "virtualbox" do |vb|
+        ## Is only on a gut feeling, we should check with the limitations of digigtalocean
+        vb.memory = "1024"
+      end
+      server.vm.hostname = "minitwit-server"
+      ## TODO: Setup of database have not been test
+      server.vm.provision "shell", privileged: false, inline: <<-SHELL
+        sudo apt install npm
+        npm install
+        npm run build
+        npm run start
+      SHELL
+    end
+  end
+  

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,36 +28,85 @@ Vagrant.configure("2") do |config|
     server.vm.hostname = "web-droplet-0"
 
     server.vm.provision "shell", inline: <<-SHELL
+      echo "Installing docker"
 
-      # Wait for any other apt process to finish
-      while fuser /var/lib/apt/lists/lock >/dev/null 2>&1; do
-        echo "Waiting for apt lock to be released..."
-        sleep 1
+      # Wait for APT and DPKG locks to be released
+      while sudo fuser /var/lib/apt/lists/lock >/dev/null 2>&1 || \
+        sudo fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1; do
+        echo "Waiting for apt/dpkg lock to be released..."
+        sleep 2
       done
 
-      echo "apt lock is released"
+      echo "APT/DPKG locks are released"
 
       # Following official docker installation: https://docs.docker.com/engine/install/ubuntu/
 
       # Add Docker's official GPG key:
       sudo apt-get update
-      sudo apt-get install ca-certificates curl
+      sudo apt-get install -y ca-certificates curl
       sudo install -m 0755 -d /etc/apt/keyrings
       sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
       sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+      # Wait for APT and DPKG locks to be released
+      while sudo fuser /var/lib/apt/lists/lock >/dev/null 2>&1 || \
+        sudo fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1; do
+        echo "Waiting for apt/dpkg lock to be released..."
+        sleep 2
+      done
+
+      echo "APT/DPKG locks are released"
 
       # Add the repository to Apt sources:
       echo \
         "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
         $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | \
         sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-      sudo apt-get update
 
+      # Wait for APT and DPKG locks to be released
+      while sudo fuser /var/lib/apt/lists/lock >/dev/null 2>&1 || \
+        sudo fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1; do
+        echo "Waiting for apt/dpkg lock to be released..."
+        sleep 2
+      done
+
+      echo "APT/DPKG locks are released"
+      
+      sudo apt-get update
       sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+    SHELL
+
+    # Add droplet to firewall through doctl
+    server.vm.provision "shell", env: { "DIGITAL_OCEAN_TOKEN" => ENV["DIGITAL_OCEAN_TOKEN"] }, inline: <<-SHELL
+      echo "Configuring firewall"
+
+      curl -sL https://github.com/digitalocean/doctl/releases/download/v1.105.0/doctl-1.105.0-linux-amd64.tar.gz | tar -xz
+      mv doctl /usr/local/bin
+
+      # Authenticate doctl
+      doctl auth init -t "$DIGITAL_OCEAN_TOKEN"
+
+      # Get this droplet's ID using metadata
+      DROPLET_ID=$(curl -s http://169.254.169.254/metadata/v1/id)
+      DROPLET_IP=$(curl -s http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address)
+
+      echo "This droplets IP addess it $DROPLET_IP"
+
+      # Get the firewall id by name
+      FIREWALL_NAME="fireball"
+      FIREWALL_ID=$(doctl compute firewall list --format ID,Name --no-header | grep "\\b$FIREWALL_NAME\\b" | awk '{print $1}')
+      
+      echo "Adding droplet to firewall: $DROPLET_ID -> $FIREWALL_ID"
+
+      # Add this droplet to the existing firewall
+      doctl compute firewall add-droplets "$FIREWALL_ID" --droplet-ids "$DROPLET_ID" 
+      doctl compute firewall add-rules "$FIREWALL_ID" --inbound-rules "protocol:tcp,ports:5432,address:$DROPLET_IP/32"
     SHELL
 
     # Run deploy.sh
     server.vm.provision "shell", inline: <<-SHELL
+      echo "Creating github user and executing deploy.sh"
+
       sudo useradd -m github -g docker
       chmod +x /home/github/deploy.sh
       # Add the github public keys to ssh file

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -99,8 +99,14 @@ Vagrant.configure("2") do |config|
       echo "Adding droplet to firewall: $DROPLET_ID -> $FIREWALL_ID"
 
       # Add this droplet to the existing firewall
-      doctl compute firewall add-droplets "$FIREWALL_ID" --droplet-ids "$DROPLET_ID" 
-      doctl compute firewall add-rules "$FIREWALL_ID" --inbound-rules "protocol:tcp,ports:5432,address:$DROPLET_IP/32"
+      doctl compute firewall add-droplets "$FIREWALL_ID" --droplet-ids "$DROPLET_ID"
+      
+      # Allow this droplet to reach the database
+      if doctl compute firewall list-by-droplet "$DROPLET_ID" --format "InboundRules" | awk -v ip="$DROPLET_IP" '$0 ~ "protocol:tcp,ports:5432,address:"ip"$"'; then
+        echo "Droplet is already allowed to contact 5432"
+      else
+        doctl compute firewall add-rules "$FIREWALL_ID" --inbound-rules "protocol:tcp,ports:5432,address:$DROPLET_IP/32"
+      fi
     SHELL
 
     # Run deploy.sh

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -107,9 +107,16 @@ Vagrant.configure("2") do |config|
     server.vm.provision "shell", inline: <<-SHELL
       echo "Creating github user and executing deploy.sh"
 
+      # Create github user and folder
       sudo useradd -m github -g docker
+
+      # Make deploy.sh executable
       chmod +x /home/github/deploy.sh
+      
       # Add the github public keys to ssh file
+      echo "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPcpMAMTqI/SdcR7dW64FzDYurU+NVezpt2/PBOxwT8z github@minitwit-joel" >> /home/github/.ssh/autorized_keys
+
+      # Execute deploy.sh script
       cd /home/github/
       /home/github/deploy.sh
     SHELL

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,9 +3,12 @@
 Vagrant.configure("2") do |config|
   config.vm.box = 'digital_ocean'
   config.vm.synced_folder ".", "/vagrant", disabled: true
-  config.vm.provision "file", source: "deploy.sh", destination: "/home/vagrant/deploy.sh"
-  config.vm.provision "file", source: ".secrets-production", destination: "/home/vagrant/.secrets-production"
-  config.vm.provision "dir"
+  config.vm.provision "file", source: "deploy.sh", destination: "/home/github/deploy.sh"
+  config.vm.provision "file", source: ".secrets-production", destination: "/home/github/.secrets-production"
+  config.vm.provision "file", source: "prometheus/prometheus.yml", destination: "/home/github/prometheus/prometheus.yml"
+  config.vm.provision "file", source: "grafana/dashboards/work_in_progress_dashboard.json", destination: "/home/github/grafana/dashboards/work_in_progress_dashboard.json"
+  config.vm.provision "file", source: "grafana/provisioning/dashboards/dashboard.yaml", destination: "/home/github/grafana/provisioning/dashboards/dashboard.yaml"
+  config.vm.provision "file", source: "grafana/provisioning/datasources/datasource.yaml", destination: "/home/github/grafana/provisioning/datasources/datasource.yaml"
   config.ssh.private_key_path = '~/.ssh/id_rsa'
   config.ssh.insert_key = false
 
@@ -55,8 +58,11 @@ Vagrant.configure("2") do |config|
 
     # Run deploy.sh
     server.vm.provision "shell", inline: <<-SHELL
-      chmod +x /home/vagrant/deploy.sh
-      /home/vagrant/deploy.sh
+      sudo useradd -m github -g docker
+      chmod +x /home/github/deploy.sh
+      # Add the github public keys to ssh file
+      cd /home/github/
+      /home/github/deploy.sh
     SHELL
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,6 +5,7 @@ Vagrant.configure("2") do |config|
   config.vm.synced_folder ".", "/vagrant", disabled: true
   config.vm.provision "file", source: "deploy.sh", destination: "/home/vagrant/deploy.sh"
   config.vm.provision "file", source: ".secrets-production", destination: "/home/vagrant/.secrets-production"
+  config.vm.provision "dir"
   config.ssh.private_key_path = '~/.ssh/id_rsa'
   config.ssh.insert_key = false
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -102,9 +102,10 @@ Vagrant.configure("2") do |config|
       doctl compute firewall add-droplets "$FIREWALL_ID" --droplet-ids "$DROPLET_ID"
       
       # Allow this droplet to reach the database
-      if doctl compute firewall list-by-droplet "$DROPLET_ID" --format "InboundRules" | awk -v ip="$DROPLET_IP" '$0 ~ "protocol:tcp,ports:5432,address:"ip"$"'; then
+      if doctl compute firewall list-by-droplet "$DROPLET_ID" --format "InboundRules" | grep -q "protocol:tcp,ports:5432,address:$DROPLET_IP"; then
         echo "Droplet is already allowed to contact 5432"
       else
+        echo "Allowing droplet to contact 5432"
         doctl compute firewall add-rules "$FIREWALL_ID" --inbound-rules "protocol:tcp,ports:5432,address:$DROPLET_IP/32"
       fi
     SHELL

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,7 +4,7 @@ docker image pull lukan707/minitwit-joel-web:latest
 docker image pull prom/prometheus:latest
 docker image pull grafana/grafana:10.2.4
 
-docker rm -f "$(docker ps -aq)"
+docker rm -f $(docker ps -aq)
 
 docker network create minitwit-network
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env  bash
-
-docker image pull lukan707/minitwit-joel-db:latest
 docker image pull lukan707/minitwit-joel-api:latest
 docker image pull lukan707/minitwit-joel-web:latest
 docker image pull prom/prometheus:latest
@@ -12,14 +10,7 @@ docker network create minitwit-network
 
 docker container prune -f
 
-docker run -d --mount source=minitiwt-devops_db-data,target=/var/lib/postgresql/data --network=minitwit-network -p 5432:5432 --name=minitwit-db --env-file .secrets lukan707/minitwit-joel-db:latest
-
-until  docker exec minitwit-db pg_isready -U postgres; do
- sleep 1
- echo 'Database is not ready'
-done
-
-docker run -d --network=minitwit-network -p 8080:8080 -p 8081:8081 --name=minitwit-api --env-file .secrets lukan707/minitwit-joel-api:latest
+docker run -d --network=minitwit-network -p 8080:8080 -p 8081:8081 --name=minitwit-api --env-file .secrets-production lukan707/minitwit-joel-api:latest
 docker run -d --network=minitwit-network -p 3000:3000 --name=minitwit-web -e "API_BASE_URL=http://minitwit-api:8080/" -e "NODE_TLS_REJECT_UNAUTHORIZED=0" lukan707/minitwit-joel-web:latest 
 
 until curl -f http://localhost:8080/api/sim/latest; do

--- a/deploy.sh
+++ b/deploy.sh
@@ -10,7 +10,19 @@ docker network create minitwit-network
 
 docker container prune -f
 
-docker run -d --network=minitwit-network -p 8080:8080 -p 8081:8081 --name=minitwit-api --env-file .secrets-production lukan707/minitwit-joel-api:latest
+if [ "$1" == "--local" ]; then
+    docker run -d --mount source=minitiwt-devops_db-data,target=/var/lib/postgresql/data --network=minitwit-network -p 5432:5432 --name=minitwit-db --env-file .secrets-local lukan707/minitwit-joel-db:latest
+
+    until  docker exec minitwit-db pg_isready -U postgres; do
+        sleep 1
+        echo 'Database is not ready'
+    done
+
+    docker run -d --network=minitwit-network -p 8080:8080 -p 8081:8081 --name=minitwit-api --env-file .secrets-local lukan707/minitwit-joel-api:latest
+else
+    docker run -d --network=minitwit-network -p 8080:8080 -p 8081:8081 --name=minitwit-api --env-file .secrets-production lukan707/minitwit-joel-api:latest
+fi
+
 docker run -d --network=minitwit-network -p 3000:3000 --name=minitwit-web -e "API_BASE_URL=http://minitwit-api:8080/" -e "NODE_TLS_REJECT_UNAUTHORIZED=0" lukan707/minitwit-joel-web:latest 
 
 until curl -f http://localhost:8080/api/sim/latest; do

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,6 +4,7 @@ docker image pull lukan707/minitwit-joel-web:latest
 docker image pull prom/prometheus:latest
 docker image pull grafana/grafana:10.2.4
 
+# shellcheck disable=SC2046
 docker rm -f $(docker ps -aq)
 
 docker network create minitwit-network

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
     networks:
       - monitoring
     env_file:
-      - .secrets
+      - .secrets-local
     ports:
       - "5432:5432"
     healthcheck:
@@ -38,7 +38,7 @@ services:
       db:
         condition: service_healthy
     env_file:
-      - .secrets
+      - .secrets-local
     ports:
       - "8080:8080"
       - "8081:8081"

--- a/logbook.md
+++ b/logbook.md
@@ -224,3 +224,15 @@ Before the vagrant file can be used to provision a new VM, it is necesarry to al
 
 We can add / edit an exisitng firewall by using the digital ocean Command Line Interface (doctl), before we execute the deploy.sh script.
 
+We also got the following error when running ```sh vagrant up``` or ```sh vagrant rebuild``` we got the following error:
+
+```sh
+web-droplet-0: Reading package lists...
+web-droplet-0: E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 2274 (apt-get)
+web-droplet-0: E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), is another process using it?
+```
+
+We solved this by checking if the apt-get lock or dpkg lock is free, each time before we use it.
+
+Please note: Sometimes we still have a race condition, where even though we just checked, the lock are not free when we try to aquire it.
+In this case it should be sufficient to re-run the vagrantfile.

--- a/logbook.md
+++ b/logbook.md
@@ -194,3 +194,33 @@ We then made a minimal dashboard that displays very basic information about the 
 
 ### Chore: Getting linters to work
 
+
+## Week 10
+
+### chore/Testing
+
+
+## Week 11
+
+### chore/Vagrant
+
+In order to getting vagrant to work on wsl, the following enviroment variable must be set in the unix enviroment:
+
+```export VAGRANT_WSL_ENABLE_WINDOWS_ACCESS="1"```
+
+Also when running the script we got the following error:
+
+```sh
+web-droplet-0: docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error mounting "/root/prometheus/prometheus.yml" to rootfs at "/etc/prometheus/prometheus.yml": create mountpoint for /etc/prometheus/prometheus.yml mount: cannot create subdirectories in "/var/lib/docker/overlay2/930bb965980a3b024fca1f8588e9361b6c4444b17cc56b9636381e11a49d4bb9/merged/etc/prometheus/prometheus.yml": not a directory: unknown: Are you trying to mount a directory onto a file (or vice-versa)? Check if the specified host path exists and is the expected type
+```
+
+This was due to Vagrant not being able to copy folders and their content recursively when using the file provision configuration, and instead what should have been files, was created as folders.
+To solve this we manually provision each file explicitly with the file provision configuration.
+Before this could work, we needed to ssh into the server and manually delete the existing folders that should have been files.
+
+Also note that the files are neither copied into the root- or vagrant user folder, but the github folder, since this is the folder that github will ssh into and re-deploy in.
+
+Before the vagrant file can be used to provision a new VM, it is necesarry to allow traffic from the new droplet to the database. Otherwise the deploy.sh script is stuck in an endless while loop.
+
+We can add / edit an exisitng firewall by using the digital ocean Command Line Interface (doctl), before we execute the deploy.sh script.
+


### PR DESCRIPTION
Be advised:

This PR breaks docker compose and deploy.sh

Instead of requiring a .secrets file, two files are required:

- .secrets-local for local development
- .secrets-production for production enviroment

The content of the two files can be found on discord.


This PR implements a Vagrantfile and seperates the web server and API server onto a new VM (droplet on digitalocean).

The readme file have been updated to describe theese changes and new procedures.