### PR TITLE
Chore/create a docker swarm

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -67,12 +67,11 @@ jobs:
             - name: Deploy to servers
                 # Configure the ~./bash_profile and deploy.sh file on the Vagrantfile
               run: |
-                ssh $SSH_USER@$SSH_HOST
+                ssh $SSH_USER@SSH_HOST_2
                 -i ~/.ssh/minitwit.key -o StrictHostKeyChecking=no
-                './deploy.sh'
-                ssh $SSH_USER@167.71.40.81
-                -i ~/.ssh/minitwit.key -o StrictHostKeyChecking=no
-                './deploy.sh'
+                "docker service update --image lukan707/minitwit-joel-api:latest minitwit-api;
+                docker service update --image lukan707/minitwit-joel-web:latest minitwit-web"
               env:
                 SSH_USER: ${{ secrets.SSH_USER }}
+                SSH_HOST_2: ${{ secrets.SSH_HOST_2 }}
                 SSH_HOST: ${{ secrets.SSH_HOST }}

--- a/README.md
+++ b/README.md
@@ -74,10 +74,16 @@ When it is ensured that the secrets file is in place,
 the containers can be brought up by running the following command in the root directory of the project:
 
 ```sh
-/.deploy.sh --local
+./deploy.sh --local
 ```
 
-Please note, that this action does not rebuild the containers from the local enviroment, but pulls the latest containers from the Docker Hub repository.
+Please note, that this action does not rebuild the containers from the local enviroment, but pulls the latest containers from the Docker Hub repository.¨
+
+The swarm will be running in the background, and can be brought down by running the following script:
+
+```sh
+./teardown.sh
+```
 
 # Provisioning the web droplet (VM) with Vagrant
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -80,6 +80,7 @@ Vagrant.configure("2") do |config|
     server.vm.provision "shell", env: { "DIGITAL_OCEAN_TOKEN" => ENV["DIGITAL_OCEAN_TOKEN"] }, inline: <<-SHELL
       echo "Configuring firewall"
 
+      # Setup doctl
       curl -sL https://github.com/digitalocean/doctl/releases/download/v1.105.0/doctl-1.105.0-linux-amd64.tar.gz | tar -xz
       mv doctl /usr/local/bin
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,34 +4,36 @@ docker image pull lukan707/minitwit-joel-web:latest
 docker image pull prom/prometheus:latest
 docker image pull grafana/grafana:10.2.4
 
-# shellcheck disable=SC2046
-docker rm -f $(docker ps -aq)
+ SWARM_IP=$(ip -4 addr show $(ip route show default | awk '/default/ {print $5}') | awk '/inet / {print $2}' | cut -d/ -f1)
 
-docker network create minitwit-network
+# # shellcheck disable=SC2046
+# docker rm -f $(docker ps -aq)
 
-docker container prune -f
+# docker network create minitwit-network
 
-if [ "$1" == "--local" ]; then
-    docker run -d --mount source=minitiwt-devops_db-data,target=/var/lib/postgresql/data --network=minitwit-network -p 5432:5432 --name=minitwit-db --env-file .secrets-local lukan707/minitwit-joel-db:latest
+# docker container prune -f
 
-    until  docker exec minitwit-db pg_isready -U postgres; do
-        sleep 1
-        echo 'Database is not ready'
-    done
+# if [ "$1" == "--local" ]; then
+#     docker run -d --mount source=minitiwt-devops_db-data,target=/var/lib/postgresql/data --network=minitwit-network -p 5432:5432 --name=minitwit-db --env-file .secrets-local lukan707/minitwit-joel-db:latest
 
-    docker run -d --network=minitwit-network -p 8080:8080 -p 8081:8081 --name=minitwit-api --env-file .secrets-local lukan707/minitwit-joel-api:latest
-else
-    docker run -d --network=minitwit-network -p 8080:8080 -p 8081:8081 --name=minitwit-api --env-file .secrets-production lukan707/minitwit-joel-api:latest
-fi
+#     until  docker exec minitwit-db pg_isready -U postgres; do
+#         sleep 1
+#         echo 'Database is not ready'
+#     done
 
-docker run -d --network=minitwit-network -p 3000:3000 --name=minitwit-web -e "API_BASE_URL=http://minitwit-api:8080/" -e "NODE_TLS_REJECT_UNAUTHORIZED=0" lukan707/minitwit-joel-web:latest 
+#     docker run -d --network=minitwit-network -p 8080:8080 -p 8081:8081 --name=minitwit-api --env-file .secrets-local lukan707/minitwit-joel-api:latest
+# else
+#     docker run -d --network=minitwit-network -p 8080:8080 -p 8081:8081 --name=minitwit-api --env-file .secrets-production lukan707/minitwit-joel-api:latest
+# fi
 
-until curl -f http://localhost:8080/api/sim/latest; do
-    sleep 1
-    echo 'Minitwit API is not ready'
-done
+# docker run -d --network=minitwit-network -p 3000:3000 --name=minitwit-web -e "API_BASE_URL=http://minitwit-api:8080/" -e "NODE_TLS_REJECT_UNAUTHORIZED=0" lukan707/minitwit-joel-web:latest 
 
-docker run -d --network=minitwit-network -p 9090:9090 --name=prometheus -v ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml prom/prometheus:latest
-docker run -d --network=minitwit-network -p 3001:3000 --name=grafana -v ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards -v ./grafana/dashboards:/var/lib/grafana/dashboards -v ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources grafana/grafana:10.2.4
+# until curl -f http://localhost:8080/api/sim/latest; do
+#     sleep 1
+#     echo 'Minitwit API is not ready'
+# done
 
-docker image prune -f 
+# docker run -d --network=minitwit-network -p 9090:9090 --name=prometheus -v ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml prom/prometheus:latest
+# docker run -d --network=minitwit-network -p 3001:3000 --name=grafana -v ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards -v ./grafana/dashboards:/var/lib/grafana/dashboards -v ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources grafana/grafana:10.2.4
+
+# docker image prune -f 

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,7 +4,7 @@ docker image pull lukan707/minitwit-joel-web:latest
 docker image pull prom/prometheus:latest
 docker image pull grafana/grafana:10.2.4
 
-SWARM_IP="$(ip -4 addr show $(ip route show default | awk '/default/ {print $5}') | awk '/inet / {print $2}' | cut -d/ -f1 | head -1 )"
+SWARM_IP="$(ip -4 addr show "$(ip route show default | awk '/default/ {print $5}')" | awk '/inet / {print $2}' | cut -d/ -f1 | head -1 )"
 
 echo "The IP of the swarm is: $SWARM_IP"
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,7 +4,7 @@ docker image pull lukan707/minitwit-joel-web:latest
 docker image pull prom/prometheus:latest
 docker image pull grafana/grafana:10.2.4
 
-SWARM_IP=$(ip -4 addr show $(ip route show default | awk '/default/ {print $5}') | awk '/inet / {print $2}' | cut -d/ -f1 | head -1 )
+SWARM_IP="$(ip -4 addr show $(ip route show default | awk '/default/ {print $5}') | awk '/inet / {print $2}' | cut -d/ -f1 | head -1 )"
 
 echo "The IP of the swarm is: $SWARM_IP"
 
@@ -17,7 +17,7 @@ fi
 
 if ! docker node inspect self --format '{{ .ManagerStatus.Leader }}'; then
     echo "Starting docker swarm"
-    docker swarm init --advertise-addr $SWARM_IP:2377 
+    docker swarm init --advertise-addr "$SWARM_IP:2377"
 fi
 
 docker network create minitwit-network \
@@ -54,7 +54,7 @@ docker service create \
     --env-file $ENV_FILE \
     lukan707/minitwit-joel-api:latest
 
-until curl -f http://$SWARM_IP:8080/api/sim/latest; do
+until curl -f "http://$SWARM_IP:8080/api/sim/latest"; do
     sleep 1
     echo 'Minitwit API is not ready'
 done

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,36 +4,87 @@ docker image pull lukan707/minitwit-joel-web:latest
 docker image pull prom/prometheus:latest
 docker image pull grafana/grafana:10.2.4
 
- SWARM_IP=$(ip -4 addr show $(ip route show default | awk '/default/ {print $5}') | awk '/inet / {print $2}' | cut -d/ -f1)
+SWARM_IP=$(ip -4 addr show $(ip route show default | awk '/default/ {print $5}') | awk '/inet / {print $2}' | cut -d/ -f1 | head -1 )
 
-# # shellcheck disable=SC2046
-# docker rm -f $(docker ps -aq)
+echo "The IP of the swarm is: $SWARM_IP"
 
-# docker network create minitwit-network
+if [ "$1" == "--local" ]; then
+    docker swarm leave --force
+    # Shellcheck sc2046 is disabled for the following line, since we actually want word splitting
+    # shellcheck disable=SC2046
+    docker rm -f $(docker ps -aq)
+fi
 
-# docker container prune -f
+if ! docker node inspect self --format '{{ .ManagerStatus.Leader }}'; then
+    echo "Starting docker swarm"
+    docker swarm init --advertise-addr $SWARM_IP:2377 
+fi
 
-# if [ "$1" == "--local" ]; then
-#     docker run -d --mount source=minitiwt-devops_db-data,target=/var/lib/postgresql/data --network=minitwit-network -p 5432:5432 --name=minitwit-db --env-file .secrets-local lukan707/minitwit-joel-db:latest
+docker network create minitwit-network \
+    --driver overlay \
+    --attachable \
 
-#     until  docker exec minitwit-db pg_isready -U postgres; do
-#         sleep 1
-#         echo 'Database is not ready'
-#     done
+ENV_FILE=".secrets-production"
 
-#     docker run -d --network=minitwit-network -p 8080:8080 -p 8081:8081 --name=minitwit-api --env-file .secrets-local lukan707/minitwit-joel-api:latest
-# else
-#     docker run -d --network=minitwit-network -p 8080:8080 -p 8081:8081 --name=minitwit-api --env-file .secrets-production lukan707/minitwit-joel-api:latest
-# fi
+if [ "$1" == "--local" ]; then
+    ENV_FILE=".secrets-local"
+    
+    docker rm -f minitwit-db
+    
+    docker run -d \
+    --mount source=minitiwt-devops_db-data,target=/var/lib/postgresql/data \
+    --network=minitwit-network \
+    -p 5432:5432 \
+    --name=minitwit-db \
+    --env-file $ENV_FILE \
+    lukan707/minitwit-joel-db:latest
 
-# docker run -d --network=minitwit-network -p 3000:3000 --name=minitwit-web -e "API_BASE_URL=http://minitwit-api:8080/" -e "NODE_TLS_REJECT_UNAUTHORIZED=0" lukan707/minitwit-joel-web:latest 
+    until  docker exec minitwit-db pg_isready -U postgres; do
+        sleep 1
+        echo 'Database is not ready'
+    done
+fi 
 
-# until curl -f http://localhost:8080/api/sim/latest; do
-#     sleep 1
-#     echo 'Minitwit API is not ready'
-# done
+docker service create \
+    --name minitwit-api \
+    --replicas 5 \
+    --network minitwit-network \
+    --publish 8080:8080 \
+    --publish 8081:8081 \
+    --env-file $ENV_FILE \
+    lukan707/minitwit-joel-api:latest
 
-# docker run -d --network=minitwit-network -p 9090:9090 --name=prometheus -v ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml prom/prometheus:latest
-# docker run -d --network=minitwit-network -p 3001:3000 --name=grafana -v ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards -v ./grafana/dashboards:/var/lib/grafana/dashboards -v ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources grafana/grafana:10.2.4
+until curl -f http://$SWARM_IP:8080/api/sim/latest; do
+    sleep 1
+    echo 'Minitwit API is not ready'
+done
 
-# docker image prune -f 
+docker service create \
+    --name minitwit-web \
+    --replicas 2 \
+    --network minitwit-network \
+    --publish 3000:3000 \
+    -e "API_BASE_URL=http://minitwit-api:8080/" \
+    -e "NODE_TLS_REJECT_UNAUTHORIZED=0" \
+    lukan707/minitwit-joel-web:latest
+
+docker rm -f prometheus
+docker rm -f grafana
+
+docker run -d \
+    --network=minitwit-network \
+    -p 9090:9090 \
+    --name=prometheus \
+    -v ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml \
+    prom/prometheus:latest
+
+docker run -d \
+    --network=minitwit-network \
+    -p 3001:3000 \
+    --name=grafana \
+    -v ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards \
+    -v ./grafana/dashboards:/var/lib/grafana/dashboards \
+    -v ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources \
+    grafana/grafana:10.2.4
+
+docker image prune -f 

--- a/logbook.md
+++ b/logbook.md
@@ -236,3 +236,70 @@ We solved this by checking if the apt-get lock or dpkg lock is free, each time b
 
 Please note: Sometimes we still have a race condition, where even though we just checked, the lock are not free when we try to aquire it.
 In this case it should be sufficient to re-run the vagrantfile.
+
+## Week 12
+
+### Creating a docker swarm
+
+We have decided to create a docker swarm on only one VM.
+This gives us:
+- better avaliability by having several replicas of the api and web server, should one fail of the replicas fails
+  (but not as good as having several manager nodes (requires several VM's) or even also several worker nodes (also requires several VM's))
+- load balancing of each service (docker swarm sets up a load balancer in front of each service)
+- automatically rolling updates
+
+The alternative is having several manager nodes, each on its own VM, and possibly several worker nodes (also each on their own VM).
+
+For now, we deem the demand from the simulator is not requiring several isntances across several VM's.
+Also the price of having minimum 3 VM's, it is recommended to have at least 3 manager nodes and always an odd number, does in light of the current user demand,
+not justify this setup.
+
+We have choosen to modify our existing ```./deploy.sh``` script to create the docker swarm.
+
+While doing so, we met an error when trying to create a service attached to the existing docker network.
+
+The solution was to configure the network as shown below.
+
+```sh
+docker network create minitwit-network \
+    --driver overlay \
+    --attachable \
+```
+The overlay type is the type of network required by a docker swarm. 
+The attachable option, defines that containers outside the swarm, are allowed to attach to the network.
+
+ The script now worked locally, but still not in production.
+
+ We found that the command for determining the public assigned IP, returned two lines with IP addresses, which caused the following error:
+
+ ```sh
+Error response from daemon: This node is not a swarm manager. Use "docker swarm init" or "docker swarm join" to connect this node to swarm and try again.
+Starting docker swarm
+Swarm initialized: current node (p5wghe15ap09hkrm1a1nbub48) is now a manager.
+
+To add a worker to this swarm, run the following command:
+
+    docker swarm join --token SWMTKN-1-3a15tf1eq4koqy3a7x4n3t4olh8a225mhykpeh5z0kemx31psg-81nwajce6x188q786byxtpd4g 127.0.0.1:2377
+ ```
+
+The fix was to adjust the command, by piping ```sh head -1 ``` at the end, so we only got the first returned.
+
+We also encountered a situation where the api endpoints where never determined ready, and the deploy script was stuck in an endless loop:
+
+```sh
+web-droplet-0:   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+    web-droplet-0:                                  Dload  Upload   Total   Spent    Left  Speed
+  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
+    web-droplet-0: curl: (7) Failed to connect to 167.71.40.81 port 8080 after 2 ms: Connection refused
+    web-droplet-0: Minitwit API is not ready
+    web-droplet-0:   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+    web-droplet-0:                                  Dload  Upload   Total   Spent    Left  Speed
+  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
+    web-droplet-0: curl: (7) Failed to connect to 167.71.40.81 port 8080 after 3 ms: Connection refused
+    web-droplet-0: Minitwit API is not ready
+    web-droplet-0:   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+    web-droplet-0:                                  Dload  Upload   Total   Spent    Left  Speed
+100    19    0    19    0     0     39      0 --:--:-- --:--:-- --:--:--    40
+```
+
+We discovered that the connection string in the enviroment file, did not have the correct ip as the host.

--- a/teardown.sh
+++ b/teardown.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env  bash
 docker swarm leave --force
 # Shellcheck sc2046 is disabled for the following line, since we actually want word splitting
 # shellcheck disable=SC2046

--- a/teardown.sh
+++ b/teardown.sh
@@ -1,0 +1,4 @@
+docker swarm leave --force
+# Shellcheck sc2046 is disabled for the following line, since we actually want word splitting
+# shellcheck disable=SC2046
+docker rm -f $(docker ps -aq)


### PR DESCRIPTION
Changes are already in production:

With this pull requests we have a new VM which runs a docker swarm that replicates our api and web contianers.
The api contianer uses the database on the existing VM.

The reserved IP on digitaloceans now points to this swarm.

The deploy workflow now applies rolling upgrades to the swarm on the new VM.